### PR TITLE
Some fixes for keyword regular expressions

### DIFF
--- a/wgsl-mode.el
+++ b/wgsl-mode.el
@@ -80,7 +80,12 @@
       (or (regexp wgsl-scalar-types-regexp)
           (seq "vec" (or "2" "3" "4"))
           (seq "mat" (or "2" "3" "4") "x" (or "2" "3" "4"))
-          (seq "array"))
+          (seq "array")
+          (seq "texture"
+               (or "" "_storage" "_depth")
+               (opt "_multisampled")
+               (or "_1d" "_2d" "_3d" "_cube")
+               (opt "_array")))
       symbol-end))
 
 (defconst wgsl-variable-name-regexp


### PR DESCRIPTION
- Use `defconst` instead of `defvar`, which is easier for development (and what `cc-fonts.el` does).
- Use `symbol-start` and `symbol-end` `rx` matchers.
- Add texture types.