### PR TITLE
Syntax highlighting fixes for builtins

### DIFF
--- a/wgsl-mode.el
+++ b/wgsl-mode.el
@@ -66,6 +66,7 @@
                   "global_invocation_id"
                   "workgroup_id"
                   "workgroup_size"
+                  "num_workgroups"
                   "sample_index"
                   "sample_mask_in"
                   "sample_mask_out"))

--- a/wgsl-mode.el
+++ b/wgsl-mode.el
@@ -40,7 +40,7 @@
 
 (defconst wgsl-attributes-regexp
   (rx (seq
-       (or "[[" "," space)
+       (or "[[" "," "@" space)
        (group (or "builtin" "block" "location" "group" "binding" "stage" "workgroup_size" "access"
                   "stride"))
        (or "]]" "("))))

--- a/wgsl-mode.el
+++ b/wgsl-mode.el
@@ -54,6 +54,7 @@
 
 (defconst wgsl-builtins-regexp
   (rx (seq
+       "@builtin("
        symbol-start
        (group (or "vertex_index"
                   "instance_index"
@@ -70,7 +71,8 @@
                   "sample_index"
                   "sample_mask_in"
                   "sample_mask_out"))
-       symbol-end)))
+       symbol-end
+       ")")))
 
 (defconst wgsl-constants-regexp
   (rx (seq symbol-start


### PR DESCRIPTION
Just wanted to start with saying that I was super happy to see a package for WGSL in Emacs! Awesome work! ❤️ 


# Description

## Adding explicit `@` to attributes definitions (line 43)
I noticed that some shaders was missing syntax highlighting for attributes. Example ([example compute shader](https://github.com/UpsettingBoy/gpgpu-rs/blob/dd1fe797e9397b59ee5185cb8a458f46837cbd7e/examples/parallel-compute/shader.wgsl)): 
<img width="1023" alt="image" src="https://github.com/acowley/wgsl-mode/assets/5732795/e2fb5325-b939-41bd-95b1-847f43425278">

Notice the group definitions, binding etc. As well as the builtin attribute in the main function arguments. Adding the `@` makes everything highlighted like expected:
<img width="1023" alt="image" src="https://github.com/acowley/wgsl-mode/assets/5732795/7ea2fdd3-cd00-4cf4-9da3-d0ca3ad5cff8">


## Missing built in`num_workgroups`
Nothing fancy, just adding [a keyword from the standard](https://www.w3.org/TR/WGSL/#built-in-values-num_workgroups) 🙂 

## The addition of `@builtin` and similar on line 57 onward
Noticed something in some shaders that made them harder to read for me. This is mostly examples you find online, like [this one](https://webgpufundamentals.org/webgpu/lessons/webgpu-compute-shaders.html). Notice that the aliases/names we give to the builtins are highlighted as regular builtins:
<img width="1120" alt="image" src="https://github.com/acowley/wgsl-mode/assets/5732795/99aab904-1fe9-4ff8-b96c-01c1648c76e4">

This made it a bit harder to read for me. With the addition of `@builtin` as a requirement for the builtin syntax highlight, it read much better for me 🙂 
<img width="1120" alt="image" src="https://github.com/acowley/wgsl-mode/assets/5732795/6e146cac-5582-487f-a45e-9ad42025c6a0">


Unsure if this is the best solution, and if it is something others care about. If it is unwanted for other people, I can remove it. It just made the experience better for me 🙂 